### PR TITLE
Basic Topography Metadata validations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(CZICheck 
-      VERSION 0.1.2
+      VERSION 0.2.0
       HOMEPAGE_URL "https://github.com/ZEISS/czicheck"
       DESCRIPTION "CZICheck is a validator for CZI-documents")
 

--- a/CZICheck/CMakeLists.txt
+++ b/CZICheck/CMakeLists.txt
@@ -164,6 +164,8 @@ if (CZICHECK_BUILD_TESTS)
           -r overlapping_scenes.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/overlapping_scenes.czi}
           -r jpgxrcompressed_inconsistent_size.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.czi}
           -r jpgxrcompressed_inconsistent_pixeltype.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.czi}
+          -r edf-missing-texture.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/edf-missing-texture.czi}
+          -r edf-superfluous.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/edf-superfluous.czi}
     )
 
     # Add a build target to populate the real data.

--- a/CZICheck/CMakeLists.txt
+++ b/CZICheck/CMakeLists.txt
@@ -70,6 +70,8 @@ set(CZICHECKSRCFILES
 "checkers/checkerOverlappingScenes.cpp"
 "checkers/checkerSubBlkBitmapValid.h"
 "checkers/checkerSubBlkBitmapValid.cpp"
+"checkers/checkerTopographyApplianceValidation.h"
+"checkers/checkerTopographyApplianceValidation.cpp"
 checkerfactory.cpp
 checkerfactory.h
 checks.h

--- a/CZICheck/checkerfactory.cpp
+++ b/CZICheck/checkerfactory.cpp
@@ -95,7 +95,7 @@ static const classEntry classesList[] =
     MakeEntry<CCheckConsecutivePlaneIndices>(),
     MakeEntry<CCheckMissingMindex>(),
     MakeEntry<CCheckBasicMetadataValidation>(),
-    MakeEntry<CCheckTopgraphyApplianceMetadata>(),
+    MakeEntry<CCheckTopographyApplianceMetadata>(),
 #if CZICHECK_XERCESC_AVAILABLE
     MakeEntry<CCheckXmlMetadataXsdValidation>(true),
 #endif

--- a/CZICheck/checkerfactory.cpp
+++ b/CZICheck/checkerfactory.cpp
@@ -20,6 +20,7 @@
 #include "checkers/checkerXmlBasicMetadataValidation.h"
 #include "checkers/checkerOverlappingScenes.h"
 #include "checkers/checkerSubBlkBitmapValid.h"
+#include "checkers/checkerTopographyApplianceValidation.h"
 
 using namespace std;
 
@@ -94,6 +95,7 @@ static const classEntry classesList[] =
     MakeEntry<CCheckConsecutivePlaneIndices>(),
     MakeEntry<CCheckMissingMindex>(),
     MakeEntry<CCheckBasicMetadataValidation>(),
+    MakeEntry<CCheckTopgraphyApplianceMetadata>(),
 #if CZICHECK_XERCESC_AVAILABLE
     MakeEntry<CCheckXmlMetadataXsdValidation>(true),
 #endif

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -37,7 +37,11 @@ void CCheckTopgraphyApplianceMetadata::RunCheck()
 
 void CCheckTopgraphyApplianceMetadata::CheckValidDimensionInTopographyDataItems(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
 {
-    this->ExtractMetaDataDimensions(czi_metadata);
+    if (!this->ExtractMetaDataDimensions(czi_metadata))
+    {
+        // we don't have any topography items and stop here
+        return;
+    }
 
     if (this->texture_views.empty() || this->heightmap_views.empty())
     {
@@ -104,7 +108,7 @@ void CCheckTopgraphyApplianceMetadata::CheckValidDimensionInTopographyDataItems(
     }
 }
 
-void CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
+bool CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
 {
     // within the TopographyData we allow
     // any number of TopographyDataItem which itself can contain a set of Texutures and a set of heightmaps
@@ -120,7 +124,7 @@ void CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shar
     if (!topo_metadata)
     {
         // there is no topo metadata section, we end here
-        return;
+        return false;
     }
 
     vector<vector<pair<wstring, wstring>>> heightmaps;
@@ -185,6 +189,13 @@ void CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shar
     {
         this->SetBoundsFromVector(tx, this->texture_views);
     }
+
+    if (!this->heightmap_views.empty() || !this->texture_views.empty())
+    {
+        return true;
+    }
+
+    return false;
 }
 
 

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#include "checkerTopographyApplianceValidation.h"
+
+using namespace std;
+using namespace libCZI;
+
+/*static*/const char* CCheckTopgraphyApplianceMetadata::kDisplayName = "Basic semantic checks for TopographyDataItems";
+/*static*/const char* CCheckTopgraphyApplianceMetadata::kShortName = "topographymetadata";
+
+CCheckTopgraphyApplianceMetadata::CCheckTopgraphyApplianceMetadata(
+    const std::shared_ptr<libCZI::ICZIReader>& reader,
+    CResultGatherer& result_gatherer,
+    const CheckerCreateInfo& additional_info) :
+    CCheckerBase(reader, result_gatherer, additional_info)
+{
+}
+
+void CCheckTopgraphyApplianceMetadata::RunCheck()
+{
+    this->result_gatherer_.StartCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
+
+    this->result_gatherer_.FinishCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
+}
+
+void CCheckTopgraphyApplianceMetadata::CheckApplianceMetadataSection()
+{
+}

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -200,7 +200,6 @@ bool CCheckTopographyApplianceMetadata::ExtractMetaDataDimensions(const std::sha
     return false;
 }
 
-
 bool CCheckTopographyApplianceMetadata::SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>& vec, std::vector<std::unordered_map<char, DimensionView>>& view)
 {
     // using a set here to ensure exactly one element per dimension

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -4,6 +4,9 @@
 
 #include "checkerTopographyApplianceValidation.h"
 #include <codecvt>
+#include <memory>
+#include <unordered_map>
+#include <utility>
 
 using namespace std;
 using namespace libCZI;
@@ -208,7 +211,7 @@ bool CCheckTopgraphyApplianceMetadata::SetBoundsFromVector(const std::vector<std
     for (const auto& element : vec)
     {
         // get the dimension index
-        char dim{ (char)element.first.back() };
+        char dim{ static_cast<char>(element.first.back()) };
         
         configurations.insert({ dim, DimensionView() });
         int value{ -1 };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -29,18 +29,14 @@ void CCheckTopgraphyApplianceMetadata::RunCheck()
     this->result_gatherer_.FinishCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
 }
 
-void CCheckTopgraphyApplianceMetadata::CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata> czi_metadata)
+void CCheckTopgraphyApplianceMetadata::CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
 {
     string appliance_path = "ImageDocument/Metadata/Appliances";
     auto metadata_node = czi_metadata->GetChildNodeReadonly(appliance_path.c_str());
 
     if (!metadata_node)
     {
-        CResultGatherer::Finding finding(CCheckTopgraphyApplianceMetadata::kCheckType);
-        finding.severity = CResultGatherer::Severity::Fatal;
-        finding.information = "The ImageDocument does not contain Appliance metadata!";
-        this->result_gatherer_.ReportFinding(finding);
-
+        // There is no Appliances section and we do not need to report that
         return;
     }
 

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -29,41 +29,10 @@ void CCheckTopgraphyApplianceMetadata::RunCheck()
     const auto czi_metadata = this->GetCziMetadataAndReportErrors(CCheckTopgraphyApplianceMetadata::kCheckType);
     if (czi_metadata)
     {
-        this->CheckTopographySectionExisting(czi_metadata);
-
         this->CheckValidDimensionInTopographyDataItems(czi_metadata);
     }
 
     this->result_gatherer_.FinishCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
-}
-
-void CCheckTopgraphyApplianceMetadata::CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
-{
-    string appliance_path{ this->kImageAppliancePath };
-    auto metadata_node = czi_metadata->GetChildNodeReadonly(this->kImageAppliancePath);
-
-    if (!metadata_node)
-    {
-        // There is no Appliances section and we do not need to report that
-        return;
-    }
-
-    appliance_path
-        .append("/Appliance[Id=")
-        .append(this->kTopographyItemId)
-        .append("]");
-
-    metadata_node = czi_metadata->GetChildNodeReadonly(appliance_path.c_str());
-
-    if (!metadata_node)
-    {
-        CResultGatherer::Finding finding(CCheckTopgraphyApplianceMetadata::kCheckType);
-        finding.severity = CResultGatherer::Severity::Info;
-        finding.information = "The ImageDocument does not contain a Topography section in the metadata.";
-        this->result_gatherer_.ReportFinding(finding);
-
-        return;
-    }
 }
 
 void CCheckTopgraphyApplianceMetadata::CheckValidDimensionInTopographyDataItems(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
@@ -177,7 +146,7 @@ void CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shar
                 };
 
             auto node_name = xmlnode->Name();
-            if (node_name == L"Texture")
+            if (node_name == CCheckTopgraphyApplianceMetadata::kTextureItemKey)
             {
                 xmlnode->EnumAttributes(textureLambda);
 
@@ -187,7 +156,7 @@ void CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shar
                 }
             }
 
-            if (node_name == L"HeightMap")
+            if (node_name == CCheckTopgraphyApplianceMetadata::kHeighMapItemKey)
             {
                 xmlnode->EnumAttributes(heighmapLambda);
 

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -22,9 +22,42 @@ void CCheckTopgraphyApplianceMetadata::RunCheck()
 {
     this->result_gatherer_.StartCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
 
+    const auto metadata_segment = this->GetCziMetadataAndReportErrors(CCheckTopgraphyApplianceMetadata::kCheckType);
+
+    this->CheckTopographySectionExisting(metadata_segment);
+
     this->result_gatherer_.FinishCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
 }
 
-void CCheckTopgraphyApplianceMetadata::CheckApplianceMetadataSection()
+void CCheckTopgraphyApplianceMetadata::CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata> czi_metadata)
 {
+    string appliance_path = "ImageDocument/Metadata/Appliances";
+    auto metadata_node = czi_metadata->GetChildNodeReadonly(appliance_path.c_str());
+
+    if (!metadata_node)
+    {
+        CResultGatherer::Finding finding(CCheckTopgraphyApplianceMetadata::kCheckType);
+        finding.severity = CResultGatherer::Severity::Fatal;
+        finding.information = "The ImageDocument does not contain Appliance metadata!";
+        this->result_gatherer_.ReportFinding(finding);
+
+        return;
+    }
+
+    appliance_path
+        .append("/Appliance[Id=")
+        .append(this->kTopographyItemId)
+        .append("]");
+
+    metadata_node = czi_metadata->GetChildNodeReadonly(appliance_path.c_str());
+
+    if (!metadata_node)
+    {
+        CResultGatherer::Finding finding(CCheckTopgraphyApplianceMetadata::kCheckType);
+        finding.severity = CResultGatherer::Severity::Fatal;
+        finding.information = "The ImageDocument does not contain a Topography section in the metadata!";
+        this->result_gatherer_.ReportFinding(finding);
+
+        return;
+    }
 }

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+// SPDX-FileCopyrightText: 2024 Carl Zeiss Microscopy GmbH
 //
 // SPDX-License-Identifier: MIT
 
 #include "checkerTopographyApplianceValidation.h"
+#include <codecvt>
 
 using namespace std;
 using namespace libCZI;
@@ -26,6 +27,8 @@ void CCheckTopgraphyApplianceMetadata::RunCheck()
     if (czi_metadata)
     {
         this->CheckTopographySectionExisting(czi_metadata);
+
+        this->ExtractMetaDataDimensions(czi_metadata);
     }
 
     this->result_gatherer_.FinishCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
@@ -33,8 +36,8 @@ void CCheckTopgraphyApplianceMetadata::RunCheck()
 
 void CCheckTopgraphyApplianceMetadata::CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
 {
-    string appliance_path = "ImageDocument/Metadata/Appliances";
-    auto metadata_node = czi_metadata->GetChildNodeReadonly(appliance_path.c_str());
+    string appliance_path{ this->kImageAppliancePath };
+    auto metadata_node = czi_metadata->GetChildNodeReadonly(this->kImageAppliancePath);
 
     if (!metadata_node)
     {
@@ -52,10 +55,157 @@ void CCheckTopgraphyApplianceMetadata::CheckTopographySectionExisting(const std:
     if (!metadata_node)
     {
         CResultGatherer::Finding finding(CCheckTopgraphyApplianceMetadata::kCheckType);
-        finding.severity = CResultGatherer::Severity::Fatal;
-        finding.information = "The ImageDocument does not contain a Topography section in the metadata!";
+        finding.severity = CResultGatherer::Severity::Info;
+        finding.information = "The ImageDocument does not contain a Topography section in the metadata.";
         this->result_gatherer_.ReportFinding(finding);
 
         return;
     }
 }
+
+void CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata)
+{
+    // within the TopographyData we allow
+    // any number of TopographyDataItem which itself can contain a set of Texutures and a set of heightmaps
+    // within the heightmaps AND Textures, each item reside in its own channel.
+    string topography_path{ this->kImageAppliancePath };
+    topography_path
+        .append("/Appliance[Id=")
+        .append(this->kTopographyItemId)
+        .append("]");
+
+    const auto topo_metadata{ czi_metadata->GetChildNodeReadonly(topography_path.c_str()) };
+
+    if (!topo_metadata)
+    {
+        // there is no topo metadata section, we end here
+        return;
+    }
+
+    vector<vector<pair<wstring, wstring>>> heightmaps;
+    vector<vector<pair<wstring, wstring>>> textures;
+
+    // we need a "named" lambda here to call it recursively
+    std::function<bool(std::shared_ptr < libCZI::IXmlNodeRead>)> enumChildrenLabmda =
+        [this, &heightmaps, &textures, &enumChildrenLabmda](std::shared_ptr<libCZI::IXmlNodeRead> xmlnode) -> bool
+        {
+            std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
+            std::vector<std::pair<std::wstring, std::wstring>> current_texture;
+            std::vector<std::pair<std::wstring, std::wstring>> current_heightmap;
+
+            auto textureLambda = [&current_texture](const std::wstring& attr, const std::wstring& val) -> bool
+                {
+                    current_texture.push_back({ attr, val });
+                    return true;
+                };
+
+            auto heighmapLambda = [&current_heightmap](const std::wstring& attr, const std::wstring& val) -> bool
+                {
+                    current_heightmap.push_back({ attr, val });
+                    return true;
+                };
+
+            auto node_name = utf8_conv.to_bytes(xmlnode->Name());
+
+            if (node_name == "Texture")
+            {
+                xmlnode->EnumAttributes(textureLambda);
+
+                if (!current_texture.empty())
+                {
+                    textures.push_back(current_texture);
+                }
+            }
+
+            if (node_name == "HeightMap")
+            {
+                xmlnode->EnumAttributes(heighmapLambda);
+
+                if (!current_heightmap.empty())
+                {
+                    heightmaps.push_back(current_heightmap);
+                }
+            }
+
+            // recursively go through child items 
+            xmlnode->EnumChildren(enumChildrenLabmda);
+
+            return true;
+        };
+
+    // call the enumeration lambda
+    topo_metadata->EnumChildren(enumChildrenLabmda);
+
+
+    // parse the dimension vectors
+    for (const auto& hm : heightmaps)
+    {
+        this->SetBoundsFromVector(hm, this->heightmap_views);
+    }
+
+    for (const auto& tx : textures)
+    {
+        this->SetBoundsFromVector(tx, this->texture_views);
+    }
+}
+
+
+bool CCheckTopgraphyApplianceMetadata::SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>& vec, std::vector<std::unordered_map<char, DimensionView>>& view)
+{
+    // using a set here to ensure exactly one element per dimension
+    unordered_map<char, DimensionView> configurations;
+
+    const wstring kStart = L"Start";
+    const wstring kSize = L"Size";
+
+    for (const auto& element : vec)
+    {
+        // get the dimension index
+        char dim{ (char)element.first.back() };
+        
+        configurations.insert({ dim, DimensionView() });
+        int value{ -1 };
+        try {
+            value = stoi(element.second);
+        }
+        catch (invalid_argument)
+        {
+            // this will ensure an "invalid" dimension later
+            value = -1;
+        }
+        
+        DimensionView* config = &configurations.at(dim);
+        if (config->DimensionIndex == DimensionIndex::invalid)
+        {
+            configurations.at(dim).DimensionIndex = Utils::CharToDimension(dim);
+        }
+
+        // -1 means not set
+        if (element.first.find(kStart) != string::npos && config->Start == -1)
+        {
+            config->Start = value;
+        }
+
+        if (element.first.find(kSize) != string::npos && config->Size == -1)
+        {
+            config->Size = value;
+        }
+
+        // '0' means not set
+        if (config->DimensionName == '0')
+        {
+            config->DimensionName = dim;
+        }
+    }
+
+
+    bool all_good{ true };
+    for (const auto& el : configurations)
+    {
+        all_good &= el.second.IsValid();
+    }
+
+    view.push_back(configurations);
+
+    return all_good;
+};

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -132,7 +132,7 @@ bool CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shar
 
     // we need a "named" lambda here to call it recursively
     std::function<bool(std::shared_ptr < libCZI::IXmlNodeRead>)> enumChildrenLabmda =
-        [this, &heightmaps, &textures, &enumChildrenLabmda](std::shared_ptr<libCZI::IXmlNodeRead> xmlnode) -> bool
+        [this, &heightmaps, &textures, &enumChildrenLabmda](const std::shared_ptr<libCZI::IXmlNodeRead> xmlnode) -> bool
         {
             std::vector<std::pair<std::wstring, std::wstring>> current_texture;
             std::vector<std::pair<std::wstring, std::wstring>> current_heightmap;
@@ -214,36 +214,37 @@ bool CCheckTopgraphyApplianceMetadata::SetBoundsFromVector(const std::vector<std
         
         configurations.insert({ dim, DimensionView() });
         int value{ -1 };
-        try {
+        try 
+        {
             value = stoi(element.second);
         }
-        catch (invalid_argument)
+        catch (const invalid_argument&)
         {
             // this will ensure an "invalid" dimension later
             value = -1;
         }
         
-        DimensionView* config = &configurations.at(dim);
-        if (config->DimensionIndex == DimensionIndex::invalid)
+        DimensionView& config = configurations.at(dim);
+        if (config.DimensionIndex == DimensionIndex::invalid)
         {
             configurations.at(dim).DimensionIndex = Utils::CharToDimension(dim);
         }
 
         // -1 means not set
-        if (element.first.find(kStart) != string::npos && config->Start == -1)
+        if (element.first.find(kStart) != string::npos && config.Start == -1)
         {
-            config->Start = value;
+            config.Start = value;
         }
 
-        if (element.first.find(kSize) != string::npos && config->Size == -1)
+        if (element.first.find(kSize) != string::npos && config.Size == -1)
         {
-            config->Size = value;
+            config.Size = value;
         }
 
         // '0' means not set
-        if (config->DimensionName == '0')
+        if (config.DimensionName == '0')
         {
-            config->DimensionName = dim;
+            config.DimensionName = dim;
         }
     }
 

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -132,7 +132,7 @@ bool CCheckTopgraphyApplianceMetadata::ExtractMetaDataDimensions(const std::shar
 
     // we need a "named" lambda here to call it recursively
     std::function<bool(std::shared_ptr < libCZI::IXmlNodeRead>)> enumChildrenLabmda =
-        [this, &heightmaps, &textures, &enumChildrenLabmda](const std::shared_ptr<libCZI::IXmlNodeRead> xmlnode) -> bool
+        [this, &heightmaps, &textures, &enumChildrenLabmda](const std::shared_ptr<libCZI::IXmlNodeRead>& xmlnode) -> bool
         {
             std::vector<std::pair<std::wstring, std::wstring>> current_texture;
             std::vector<std::pair<std::wstring, std::wstring>> current_heightmap;

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -22,9 +22,11 @@ void CCheckTopgraphyApplianceMetadata::RunCheck()
 {
     this->result_gatherer_.StartCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
 
-    const auto metadata_segment = this->GetCziMetadataAndReportErrors(CCheckTopgraphyApplianceMetadata::kCheckType);
-
-    this->CheckTopographySectionExisting(metadata_segment);
+    const auto czi_metadata = this->GetCziMetadataAndReportErrors(CCheckTopgraphyApplianceMetadata::kCheckType);
+    if (czi_metadata)
+    {
+        this->CheckTopographySectionExisting(czi_metadata);
+    }
 
     this->result_gatherer_.FinishCheck(CCheckTopgraphyApplianceMetadata::kCheckType);
 }

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -8,6 +8,9 @@
 
 class CCheckTopgraphyApplianceMetadata : public IChecker, CCheckerBase
 {
+private:
+    const char* kTopographyItemId = "Topography:1";
+
 public:
     static const CZIChecks kCheckType = CZIChecks::ApplianceMetadataTopographyItemValid;
     static const char* kDisplayName;
@@ -18,6 +21,7 @@ public:
         CResultGatherer& result_gatherer,
         const CheckerCreateInfo& additional_info);
     void RunCheck() override;
+
 private:
-    void CheckApplianceMetadataSection();
+    void CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata> czi_metadata);
 };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -9,7 +9,7 @@
 class CCheckTopgraphyApplianceMetadata : public IChecker, CCheckerBase
 {
 private:
-    const char* kTopographyItemId = "Topography:1";
+    static constexpr const char* kTopographyItemId = "Topography:1";
 
 public:
     static const CZIChecks kCheckType = CZIChecks::ApplianceMetadataTopographyItemValid;
@@ -23,5 +23,5 @@ public:
     void RunCheck() override;
 
 private:
-    void CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata> czi_metadata);
+    void CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -1,15 +1,37 @@
-// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+// SPDX-FileCopyrightText: 2024 Carl Zeiss Microscopy GmbH
 //
 // SPDX-License-Identifier: MIT
 
 #pragma once
 
 #include "checkerbase.h"
+#include <vector>
+#include <string>
+
+struct DimensionView {
+    libCZI::DimensionIndex DimensionIndex{ libCZI::DimensionIndex::invalid };
+    char DimensionName{'0'};
+    int Start{ -1 };
+    int Size{ -1 };
+    bool IsValid() const
+    {
+        // a Size is not neccessarily needed iot be valid here!
+        // if (this->Start >= 0 && this->Size > 0 && this->DimensionIndex != libCZI::DimensionIndex::invalid)
+        if (this->Start >= 0 && this->DimensionIndex != libCZI::DimensionIndex::invalid)
+            return true;
+
+        return false;
+    };
+};
 
 class CCheckTopgraphyApplianceMetadata : public IChecker, CCheckerBase
 {
 private:
     static constexpr const char* kTopographyItemId = "Topography:1";
+    static constexpr const char* kImageAppliancePath = "ImageDocument/Metadata/Appliances";
+
+    std::vector<std::unordered_map<char, DimensionView>> texture_views;
+    std::vector<std::unordered_map<char, DimensionView>> heightmap_views;
 
 public:
     static const CZIChecks kCheckType = CZIChecks::ApplianceMetadataTopographyItemValid;
@@ -24,4 +46,8 @@ public:
 
 private:
     void CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
+
+private:
+    bool SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>&, std::vector<std::unordered_map<char, DimensionView>>&);
+    void ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -46,6 +46,7 @@ public:
 
 private:
     void CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
+    void CheckValidDimensionInTopographyDataItems(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 
 private:
     bool SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>&, std::vector<std::unordered_map<char, DimensionView>>&);

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -54,5 +54,5 @@ private:
 
 private:
     bool SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>&, std::vector<std::unordered_map<char, DimensionView>>&);
-    void ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
+    bool ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -18,10 +18,12 @@ struct DimensionView {
     int Size{ -1 };
     bool IsValid() const
     {
-        // a Size is not neccessarily needed iot be valid here!
-        // if (this->Start >= 0 && this->Size > 0 && this->DimensionIndex != libCZI::DimensionIndex::invalid)
+        // this is an object used exclusively for this checker
+        //  a Size (SizeC, SizeX, etc.) is not needed to yield a "valid" dimension for this
         if (this->Start >= 0 && this->DimensionIndex != libCZI::DimensionIndex::invalid)
+        {
             return true;
+        }
 
         return false;
     };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "checkerbase.h"
+
+class CCheckTopgraphyApplianceMetadata : public IChecker, CCheckerBase
+{
+public:
+    static const CZIChecks kCheckType = CZIChecks::ApplianceMetadataTopographyItemValid;
+    static const char* kDisplayName;
+    static const char* kShortName;
+    
+    CCheckTopgraphyApplianceMetadata(
+        const std::shared_ptr<libCZI::ICZIReader>& reader,
+        CResultGatherer& result_gatherer,
+        const CheckerCreateInfo& additional_info);
+    void RunCheck() override;
+private:
+    void CheckApplianceMetadataSection();
+};

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include "checkerbase.h"
+#include <memory>
 #include <vector>
 #include <string>
+#include <unordered_map>
+#include <utility>
 
 struct DimensionView {
     libCZI::DimensionIndex DimensionIndex{ libCZI::DimensionIndex::invalid };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -11,41 +11,43 @@
 #include <unordered_map>
 #include <utility>
 
-struct DimensionView {
-    libCZI::DimensionIndex DimensionIndex{ libCZI::DimensionIndex::invalid };
-    char DimensionName{'0'};
-    int Start{ -1 };
-    int Size{ -1 };
-    bool IsValid() const
-    {
-        // this is an object used exclusively for this checker
-        //  a Size (SizeC, SizeX, etc.) is not needed to yield a "valid" dimension for this
-        if (this->Start >= 0 && this->DimensionIndex != libCZI::DimensionIndex::invalid)
-        {
-            return true;
-        }
-
-        return false;
-    };
-};
-
-class CCheckTopgraphyApplianceMetadata : public IChecker, CCheckerBase
+/// This checker validates the topography-XML-metadata.
+class CCheckTopographyApplianceMetadata : public IChecker, CCheckerBase
 {
 private:
+    struct DimensionView
+    {
+        libCZI::DimensionIndex DimensionIndex{ libCZI::DimensionIndex::invalid };
+        char DimensionName{ '\0' };
+        int Start{ -1 };
+        int Size{ -1 };
+        bool IsValid() const
+        {
+            // this is an object used exclusively for this checker
+            //  a Size (SizeC, SizeX, etc.) is not needed to yield a "valid" dimension for this
+            if (this->Start >= 0 && this->DimensionIndex != libCZI::DimensionIndex::invalid)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    };
+
     static constexpr const char* kTopographyItemId = "Topography:1";
     static constexpr const char* kImageAppliancePath = "ImageDocument/Metadata/Appliances";
     static constexpr const wchar_t* kTextureItemKey = L"Texture";
-    static constexpr const wchar_t* kHeighMapItemKey = L"HeightMap";
+    static constexpr const wchar_t* kHeightMapItemKey = L"HeightMap";
 
-    std::vector<std::unordered_map<char, DimensionView>> texture_views;
-    std::vector<std::unordered_map<char, DimensionView>> heightmap_views;
+    std::vector<std::unordered_map<char, DimensionView>> texture_views_;
+    std::vector<std::unordered_map<char, DimensionView>> heightmap_views_;
 
 public:
     static const CZIChecks kCheckType = CZIChecks::ApplianceMetadataTopographyItemValid;
     static const char* kDisplayName;
     static const char* kShortName;
     
-    CCheckTopgraphyApplianceMetadata(
+    CCheckTopographyApplianceMetadata(
         const std::shared_ptr<libCZI::ICZIReader>& reader,
         CResultGatherer& result_gatherer,
         const CheckerCreateInfo& additional_info);
@@ -54,7 +56,6 @@ public:
 private:
     void CheckValidDimensionInTopographyDataItems(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 
-private:
     bool SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>&, std::vector<std::unordered_map<char, DimensionView>>&);
     bool ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -32,6 +32,8 @@ class CCheckTopgraphyApplianceMetadata : public IChecker, CCheckerBase
 private:
     static constexpr const char* kTopographyItemId = "Topography:1";
     static constexpr const char* kImageAppliancePath = "ImageDocument/Metadata/Appliances";
+    static constexpr const wchar_t* kTextureItemKey = L"Texture";
+    static constexpr const wchar_t* kHeighMapItemKey = L"HeightMap";
 
     std::vector<std::unordered_map<char, DimensionView>> texture_views;
     std::vector<std::unordered_map<char, DimensionView>> heightmap_views;
@@ -48,7 +50,6 @@ public:
     void RunCheck() override;
 
 private:
-    void CheckTopographySectionExisting(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
     void CheckValidDimensionInTopographyDataItems(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 
 private:

--- a/CZICheck/checks.h
+++ b/CZICheck/checks.h
@@ -52,5 +52,8 @@ enum class CZIChecks
 
     ConsistentMIndex,   ///< To be done, not yet implemented.
 
-    AttachmentDirectoryPositionsWithinRange ///< To be done, not yet implemented.
+    AttachmentDirectoryPositionsWithinRange, ///< To be done, not yet implemented.
+
+    /// The Applicance Metadata specified for TopographyDataItem(s) are valid
+    ApplianceMetadataTopographyItemValid,
 };

--- a/Test/CZICheckSamples/TestCasesLists.txt
+++ b/Test/CZICheckSamples/TestCasesLists.txt
@@ -28,3 +28,5 @@ inaccessible_file.czi,5,*
 overlapping_scenes.czi,2,overlapping_scenes.txt
 jpgxrcompressed_inconsistent_size.czi,2,jpgxrcompressed_inconsistent_size.txt
 jpgxrcompressed_inconsistent_pixeltype.czi,2,jpgxrcompressed_inconsistent_pixeltype.txt
+edf-missing-texture.czi,2,edf-missing-texture.txt
+edf-superfluous.czi,2,edf-superfluous.txt

--- a/Test/CZICheckSamples/differentpixeltypeinchannel.txt
+++ b/Test/CZICheckSamples/differentpixeltypeinchannel.txt
@@ -17,6 +17,9 @@ Test "validate the XML-metadata against XSD-schema" :
  WARN
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" :
+  Could not read metadata-segment
+ WARN
 
 
 Result: With Warnings

--- a/Test/CZICheckSamples/duplicate_coordinates.txt
+++ b/Test/CZICheckSamples/duplicate_coordinates.txt
@@ -17,6 +17,9 @@ Test "validate the XML-metadata against XSD-schema" :
  WARN
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" :
+  Could not read metadata-segment
+ WARN
 
 
 Result: Errors Detected

--- a/Test/CZICheckSamples/edf-missing-texture.czi.md5
+++ b/Test/CZICheckSamples/edf-missing-texture.czi.md5
@@ -1,0 +1,1 @@
+e1bcf912d13b002f32e8c325ab4ecac6

--- a/Test/CZICheckSamples/edf-missing-texture.txt
+++ b/Test/CZICheckSamples/edf-missing-texture.txt
@@ -8,6 +8,12 @@ Test "Check that planes indices start at 0" : OK
 Test "Check that planes have consecutive indices" : OK
 Test "check if all subblocks have the M index" : OK
 Test "Basic semantic checks of the XML-metadata" : OK
+Test "validate the XML-metadata against XSD-schema" :
+  (94,22): no declaration found for element 'RotationCenter'
+  (98,15): element 'RotationCenter' is not allowed for content model 'All(SessionMatrix?,HolderZeissName?,HolderZeissId?,HolderCwsId?,SessionCount?,SessionRotationAtStart?,CustomAttributes?)'
+  (105,21): no declaration found for element 'LookupTables'
+  <3 more findings omitted> 
+ FAIL
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
 Test "Basic semantic checks for TopographyDataItems" :

--- a/Test/CZICheckSamples/edf-missing-texture.txt
+++ b/Test/CZICheckSamples/edf-missing-texture.txt
@@ -1,5 +1,6 @@
-Test "check subblock's coordinates for 'consistent dimensions'" : OK
 Test "SubBlock-Segment in SubBlockDirectory within file" : OK
+Test "SubBlock-Segments in SubBlockDirectory are valid" : OK
+Test "check subblock's coordinates for 'consistent dimensions'" : OK
 Test "check subblock's coordinates being unique" : OK
 Test "check whether the document uses the deprecated 'B-index'" : OK
 Test "check that the subblocks of a channel have the same pixeltype" : OK
@@ -7,11 +8,11 @@ Test "Check that planes indices start at 0" : OK
 Test "Check that planes have consecutive indices" : OK
 Test "check if all subblocks have the M index" : OK
 Test "Basic semantic checks of the XML-metadata" : OK
-Test "Basic semantic checks for TopographyDataItems" :
-  The image contains incomplete TopographyDataItems.
- WARN
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" :
+  The image contains TopographyDataItems that do not define a channel.
+ FAIL
 
 
-Result: With Warnings
+Result: Errors Detected

--- a/Test/CZICheckSamples/edf-missing-texture.txt
+++ b/Test/CZICheckSamples/edf-missing-texture.txt
@@ -9,9 +9,9 @@ Test "Check that planes have consecutive indices" : OK
 Test "check if all subblocks have the M index" : OK
 Test "Basic semantic checks of the XML-metadata" : OK
 Test "validate the XML-metadata against XSD-schema" :
-  (94,22): no declaration found for element 'RotationCenter'
-  (98,15): element 'RotationCenter' is not allowed for content model 'All(SessionMatrix?,HolderZeissName?,HolderZeissId?,HolderCwsId?,SessionCount?,SessionRotationAtStart?,CustomAttributes?)'
-  (105,21): no declaration found for element 'LookupTables'
+  (101,22): no declaration found for element 'RotationCenter'
+  (105,15): element 'RotationCenter' is not allowed for content model 'All(SessionMatrix?,HolderZeissName?,HolderZeissId?,HolderCwsId?,SessionCount?,SessionRotationAtStart?,CustomAttributes?)'
+  (112,21): no declaration found for element 'LookupTables'
   <3 more findings omitted> 
  FAIL
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK

--- a/Test/CZICheckSamples/edf-missing-texture.txt
+++ b/Test/CZICheckSamples/edf-missing-texture.txt
@@ -1,0 +1,17 @@
+Test "check subblock's coordinates for 'consistent dimensions'" : OK
+Test "SubBlock-Segment in SubBlockDirectory within file" : OK
+Test "check subblock's coordinates being unique" : OK
+Test "check whether the document uses the deprecated 'B-index'" : OK
+Test "check that the subblocks of a channel have the same pixeltype" : OK
+Test "Check that planes indices start at 0" : OK
+Test "Check that planes have consecutive indices" : OK
+Test "check if all subblocks have the M index" : OK
+Test "Basic semantic checks of the XML-metadata" : OK
+Test "Basic semantic checks for TopographyDataItems" :
+  The image contains incomplete TopographyDataItems.
+ WARN
+Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
+Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+
+
+Result: With Warnings

--- a/Test/CZICheckSamples/edf-superfluous.czi.md5
+++ b/Test/CZICheckSamples/edf-superfluous.czi.md5
@@ -1,0 +1,1 @@
+dbecd3a299bc85eac7d45ab77ad3f4dc

--- a/Test/CZICheckSamples/edf-superfluous.txt
+++ b/Test/CZICheckSamples/edf-superfluous.txt
@@ -1,0 +1,18 @@
+Test with superfluous topography data:
+Test "check subblock's coordinates for 'consistent dimensions'" : OK
+Test "SubBlock-Segment in SubBlockDirectory within file" : OK
+Test "check subblock's coordinates being unique" : OK
+Test "check whether the document uses the deprecated 'B-index'" : OK
+Test "check that the subblocks of a channel have the same pixeltype" : OK
+Test "Check that planes indices start at 0" : OK
+Test "Check that planes have consecutive indices" : OK
+Test "check if all subblocks have the M index" : OK
+Test "Basic semantic checks of the XML-metadata" : OK
+Test "Basic semantic checks for TopographyDataItems" :
+  There are superfluous dimensions specified in the TopographyDataItems. This might yield errors.
+ WARN
+Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
+Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+
+
+Result: With Warnings

--- a/Test/CZICheckSamples/edf-superfluous.txt
+++ b/Test/CZICheckSamples/edf-superfluous.txt
@@ -1,6 +1,6 @@
-Test with superfluous topography data:
-Test "check subblock's coordinates for 'consistent dimensions'" : OK
 Test "SubBlock-Segment in SubBlockDirectory within file" : OK
+Test "SubBlock-Segments in SubBlockDirectory are valid" : OK
+Test "check subblock's coordinates for 'consistent dimensions'" : OK
 Test "check subblock's coordinates being unique" : OK
 Test "check whether the document uses the deprecated 'B-index'" : OK
 Test "check that the subblocks of a channel have the same pixeltype" : OK
@@ -8,11 +8,11 @@ Test "Check that planes indices start at 0" : OK
 Test "Check that planes have consecutive indices" : OK
 Test "check if all subblocks have the M index" : OK
 Test "Basic semantic checks of the XML-metadata" : OK
+Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
+Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
 Test "Basic semantic checks for TopographyDataItems" :
   There are superfluous dimensions specified in the TopographyDataItems. This might yield errors.
  WARN
-Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
-Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
 
 
 Result: With Warnings

--- a/Test/CZICheckSamples/edf-superfluous.txt
+++ b/Test/CZICheckSamples/edf-superfluous.txt
@@ -8,6 +8,12 @@ Test "Check that planes indices start at 0" : OK
 Test "Check that planes have consecutive indices" : OK
 Test "check if all subblocks have the M index" : OK
 Test "Basic semantic checks of the XML-metadata" : OK
+Test "validate the XML-metadata against XSD-schema" :
+  (121,22): no declaration found for element 'RotationCenter'
+  (125,15): element 'RotationCenter' is not allowed for content model 'All(SessionMatrix?,HolderZeissName?,HolderZeissId?,HolderCwsId?,SessionCount?,SessionRotationAtStart?,CustomAttributes?)'
+  (139,21): no declaration found for element 'LookupTables'
+  <3 more findings omitted> 
+ FAIL
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
 Test "Basic semantic checks for TopographyDataItems" :
@@ -15,4 +21,4 @@ Test "Basic semantic checks for TopographyDataItems" :
  WARN
 
 
-Result: With Warnings
+Result: Errors Detected

--- a/Test/CZICheckSamples/inconsistent_coordinates.txt
+++ b/Test/CZICheckSamples/inconsistent_coordinates.txt
@@ -17,6 +17,9 @@ Test "validate the XML-metadata against XSD-schema" :
  WARN
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" :
+  Could not read metadata-segment
+ WARN
 
 
 Result: Errors Detected

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt
@@ -13,6 +13,7 @@ Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping"
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" :
   Error decoding subblock #0 with compression "jpgxr"
  FAIL
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: Errors Detected

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt
@@ -13,6 +13,7 @@ Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping"
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" :
   Error decoding subblock #0 with compression "jpgxr"
  FAIL
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: Errors Detected

--- a/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt
+++ b/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt
@@ -13,6 +13,7 @@ Test "Basic semantic checks of the XML-metadata" : OK
 Test "validate the XML-metadata against XSD-schema" : OK
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: With Warnings

--- a/Test/CZICheckSamples/negative_plane_start_index.txt
+++ b/Test/CZICheckSamples/negative_plane_start_index.txt
@@ -15,6 +15,7 @@ Test "Basic semantic checks of the XML-metadata" :
 Test "validate the XML-metadata against XSD-schema" : OK
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: With Warnings

--- a/Test/CZICheckSamples/overlapping_scenes.txt
+++ b/Test/CZICheckSamples/overlapping_scenes.txt
@@ -23,6 +23,7 @@ Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping"
   <1 more finding omitted> 
  WARN
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: Errors Detected

--- a/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt
+++ b/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt
@@ -20,6 +20,7 @@ Test "validate the XML-metadata against XSD-schema" :
  FAIL
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: Errors Detected

--- a/Test/CZICheckSamples/positive_plane_start_index.txt
+++ b/Test/CZICheckSamples/positive_plane_start_index.txt
@@ -15,6 +15,7 @@ Test "Basic semantic checks of the XML-metadata" :
 Test "validate the XML-metadata against XSD-schema" : OK
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: With Warnings

--- a/Test/CZICheckSamples/sparse_planes.txt
+++ b/Test/CZICheckSamples/sparse_planes.txt
@@ -15,6 +15,7 @@ Test "Basic semantic checks of the XML-metadata" :
 Test "validate the XML-metadata against XSD-schema" : OK
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
 Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" : OK
 
 
 Result: With Warnings

--- a/documentation/description_of_checkers.md
+++ b/documentation/description_of_checkers.md
@@ -18,7 +18,8 @@ The following table lists the available checkers and gives a short description o
 |basicxmlmetadata|Same basic checks of the XML-metadata, which is semantically validated with the content of the file.|
 |xmlmetadataschema|Validate the XML-metadata against the schema for it.|
 |overlappingscenes|Test for subblocks within different scenes are overlapping (on pyramid-layer 0).|
-|subblkbitmapvalid|Read all subblocks from the file, ensure their syntactical validity and decode the bitmap. Note that this check requires reading all data from disk and decoding, so it may be time consuming. ||
+|subblkbitmapvalid|Read all subblocks from the file, ensure their syntactical validity and decode the bitmap. Note that this check requires reading all data from disk and decoding, so it may be time consuming. |
+|topographymetadata|Checks whether the given TopographyDataItems supplied in the Appliances metadata section of a czi image comply with the specification and the content of that czi image.|
 
 
 ## Details
@@ -98,3 +99,7 @@ This check is more thorough than the check 'subblksegmentsvalid', as it also che
 so it is not necessary to run both checks.
 Note that this check requires reading all data from disk, and in case of compressed data it is decoded, so it may be time consuming.
 
+### topographymetadata
+This checker is implemented in the file 'checkerTopographyApplianceValidation.cpp'.  
+It checks if an image contains a Topography section in its 'Appliances' metadata section.
+If there is such a section, it checks if both 'Textures' and 'HeightMaps' are given within 'TopographyDataItem' containers in the Appliances section. Each of the entries in 'Textures' and 'HeighMaps' should specify a channel (via a 'StartC' information) and no other information. That other information is considered superfluous.

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -6,3 +6,4 @@ version history                 {#version_history}
  0.1.0          |                                                      | initial release
  0.1.1          | [4](https://github.com/ZEISS/czicheck/pull/4)        | update of metadata-schema (compression)
  0.1.2          | [9](https://github.com/ZEISS/czicheck/pull/9)        | add checker "subblkbitmapvalid"
+ 0.2.0          | [10](https://github.com/ZEISS/czicheck/pull/10)      | add checker "topographymetadata"


### PR DESCRIPTION
## Description

Extended Depth of Focus (EDF) images are described in a czi-image by means of "Appliance" metadata items called "TopographyDataItem". It is important for the consuming application that the data specified there defines channels (indices) where "Textures" (the subblock that contain image pixeldata) and "HeightMaps" (the subblock that contain height information) can be found. At the same time, there should not be any additional information in these sections that is not defined by the czi specification.

This PR adds a basic metadata check for these topography sections. It implements the following checks: 
1. If both information  HeightMap AND Texture information is present in the metadata
2. Each of the entries in 'Textures' and 'HeighMaps' specifies a channel (via a 'StartC' information) 
3. No information other than 'StartC' is specified in the items. That other information is considered superfluous.  

Fixes #8 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Malformed czi images were added to the testdata source. These are used with 2 new automated tests validating the introduced changes.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
