### PR TITLE
Enable strict parsing and turning on/off per command line option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(LIBCZI_INCLUDE_DIR "${libczi_SOURCE_DIR}/Src/libCZI")
 
 # This option enables/disables the tests for the CZICheck-application. If enabled, the test
 #  runs with a ctest run (and test-data is being downloaded)
-option(CZICHECK_BUILD_TESTS "Run the tests-suite with CTest (requires external files)" OFF)
+option(CZICHECK_BUILD_TESTS "Run the tests-suite with CTest (requires external files)" ON)
 
 if (CZICHECK_BUILD_TESTS)
  enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(LIBCZI_INCLUDE_DIR "${libczi_SOURCE_DIR}/Src/libCZI")
 
 # This option enables/disables the tests for the CZICheck-application. If enabled, the test
 #  runs with a ctest run (and test-data is being downloaded)
-option(CZICHECK_BUILD_TESTS "Run the tests-suite with CTest (requires external files)" ON)
+option(CZICHECK_BUILD_TESTS "Run the tests-suite with CTest (requires external files)" OFF)
 
 if (CZICHECK_BUILD_TESTS)
  enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(CZICheck 
-      VERSION 0.2.1
+      VERSION 0.3.0
       HOMEPAGE_URL "https://github.com/ZEISS/czicheck"
       DESCRIPTION "CZICheck is a validator for CZI-documents")
 

--- a/CZICheck/cmdlineoptions.cpp
+++ b/CZICheck/cmdlineoptions.cpp
@@ -72,15 +72,14 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         }
     };
 
-    // CLI11-validator for the option "--printdetails".
-    struct PrintDetailsValidator : public CLI::Validator
+    struct BooleanArgumentValidator : public CLI::Validator
     {
-        PrintDetailsValidator()
+        BooleanArgumentValidator(const std::string& argument_key)
         {
-            this->func_ = [](const std::string& str) -> string
+            this->func_ = [argument_key](const std::string& str) -> string
                 {
                     string error_message;
-                    const bool parsed_ok = CCmdLineOptions::ParseBooleanArgument("printdetails", str, nullptr, &error_message);
+                    const bool parsed_ok = CCmdLineOptions::ParseBooleanArgument(argument_key, str, nullptr, &error_message);
                     if (!parsed_ok)
                     {
                         throw CLI::ValidationError(error_message);
@@ -91,23 +90,18 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         }
     };
 
-    // CLI11-validator for the option "--laxparsing".
-    struct LaxParsingValidator : public CLI::Validator
+    // CLI11-validator for the option "--printdetails".
+    struct PrintDetailsValidator : public BooleanArgumentValidator
     {
-        LaxParsingValidator()
-        {
-            this->func_ = [](const std::string& str) -> string
-                {
-                    string error_message;
-                    const bool parsed_ok = CCmdLineOptions::ParseBooleanArgument("laxparsing", str, nullptr, &error_message);
-                    if (!parsed_ok)
-                    {
-                        throw CLI::ValidationError(error_message);
-                    }
+        PrintDetailsValidator() : BooleanArgumentValidator("printdetails")
+        {}
+    };
 
-                    return {};
-                };
-        }
+    // CLI11-validator for the option "--laxparsing".
+    struct LaxParsingValidator : public BooleanArgumentValidator
+    {
+        LaxParsingValidator() : BooleanArgumentValidator("laxparsing")
+        {}
     };
 
     static const ChecksValidator checks_validator;

--- a/CZICheck/cmdlineoptions.cpp
+++ b/CZICheck/cmdlineoptions.cpp
@@ -157,7 +157,7 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
     app.add_option("-l,--laxparsing", lax_parsing_enabled,
         "Specifies whether lax parsing for file opening is enabled.\n"
         "The argument may be one of 'true', 'false', 'yes'\n"
-        "or 'no'.\n")
+        "or 'no'. Default is 'no'.\n")
         ->option_text("BOOLEAN")
         ->check(lax_parsing_validator);
     // Parse the command line arguments

--- a/CZICheck/cmdlineoptions.cpp
+++ b/CZICheck/cmdlineoptions.cpp
@@ -74,7 +74,7 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
 
     struct BooleanArgumentValidator : public CLI::Validator
     {
-        BooleanArgumentValidator(const std::string& argument_key)
+        explicit BooleanArgumentValidator(const std::string& argument_key)
         {
             this->func_ = [argument_key](const std::string& str) -> string
                 {

--- a/CZICheck/cmdlineoptions.h
+++ b/CZICheck/cmdlineoptions.h
@@ -19,6 +19,7 @@ private:
     std::vector<CZIChecks> checks_enabled_;
     int max_number_of_findings_to_print_;
     bool print_details_of_messages_;
+    bool lax_parsing_enabled_;
 public:
     /// Values that represent the result of the "Parse"-operation.
     enum class ParseResult
@@ -41,6 +42,7 @@ public:
     [[nodiscard]] const std::wstring& GetCZIFilename() const { return this->czi_filename_; }
     [[nodiscard]] int GetMaxNumberOfMessagesToPrint() const { return this->max_number_of_findings_to_print_; }
     [[nodiscard]] bool GetPrintDetailsOfMessages() const { return this->print_details_of_messages_; }
+    [[nodiscard]] bool GetLaxParsingEnabled() const { return this->lax_parsing_enabled_; }
     [[nodiscard]] const std::vector<CZIChecks>& GetChecksEnabled() const { return this->checks_enabled_; }
     [[nodiscard]] const std::shared_ptr<ILog>& GetLog() const { return this->log_; }
 private:

--- a/CZICheck/cmdlineoptions.h
+++ b/CZICheck/cmdlineoptions.h
@@ -46,7 +46,7 @@ public:
     [[nodiscard]] const std::vector<CZIChecks>& GetChecksEnabled() const { return this->checks_enabled_; }
     [[nodiscard]] const std::shared_ptr<ILog>& GetLog() const { return this->log_; }
 private:
-    static bool ParsePrintDetailsArgument(const std::string& str, bool* boolean_value, std::string* error_message);
+    static bool ParseBooleanArgument(const std::string& argument_key, const std::string& argument_value, bool* boolean_value, std::string* error_message);
     static bool ParseChecksArgument(const std::string& str, std::vector<CZIChecks>* checks_enabled, std::string* error_message);
 
     /// Information about a "checker item" and whether it is to be added or removed.

--- a/CZICheck/runchecks.cpp
+++ b/CZICheck/runchecks.cpp
@@ -37,7 +37,9 @@ bool CRunChecks::Run(CResultGatherer::AggregatedResult& result)
 
     try
     {
-        spReader->Open(stream);
+        ICZIReader::OpenOptions options;
+        options.lax_subblock_coordinate_checks = this->opts.GetLaxParsingEnabled();
+        spReader->Open(stream, &options);
     }
     catch (exception& ex)
     {

--- a/CZICheck/test/CZICheckRunTests.py
+++ b/CZICheck/test/CZICheckRunTests.py
@@ -132,7 +132,7 @@ def compare_result_of_test_to_knowngood(result: str, knowngood: str):
 def check_file(cmdline_parameters: Parameters, czi_filename: str, expected_result_file: str, expected_returncode: int):
     cmdlineargs = [cmdline_parameters.get_fully_qualified_czicheck_executable(), '-s',
                    cmdline_parameters.build_fully_qualified_czi_filename(czi_filename),
-                   '-c','all', '-l', 'true']
+                   '-c','all', '--laxparsing', 'true']
     print(f"test {czi_filename}")
 
     output = subprocess.run(cmdlineargs, capture_output=True, check=False, universal_newlines=True)

--- a/CZICheck/test/CZICheckRunTests.py
+++ b/CZICheck/test/CZICheckRunTests.py
@@ -132,7 +132,7 @@ def compare_result_of_test_to_knowngood(result: str, knowngood: str):
 def check_file(cmdline_parameters: Parameters, czi_filename: str, expected_result_file: str, expected_returncode: int):
     cmdlineargs = [cmdline_parameters.get_fully_qualified_czicheck_executable(), '-s',
                    cmdline_parameters.build_fully_qualified_czi_filename(czi_filename),
-                   '-c','all', '-l true']
+                   '-c','all', '-l', 'true']
     print(f"test {czi_filename}")
 
     output = subprocess.run(cmdlineargs, capture_output=True, check=False, universal_newlines=True)

--- a/CZICheck/test/CZICheckRunTests.py
+++ b/CZICheck/test/CZICheckRunTests.py
@@ -132,7 +132,7 @@ def compare_result_of_test_to_knowngood(result: str, knowngood: str):
 def check_file(cmdline_parameters: Parameters, czi_filename: str, expected_result_file: str, expected_returncode: int):
     cmdlineargs = [cmdline_parameters.get_fully_qualified_czicheck_executable(), '-s',
                    cmdline_parameters.build_fully_qualified_czi_filename(czi_filename),
-                   '-c','all']
+                   '-c','all', '-l true']
     print(f"test {czi_filename}")
 
     output = subprocess.run(cmdlineargs, capture_output=True, check=False, universal_newlines=True)

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -64,6 +64,7 @@ Available checkers (checkers enabled with the default set are marked with '*'):
 * "minallsubblks" -> check if all subblocks have the M index
 * "basicxmlmetadata" -> Basic semantic checks of the XML-metadata
 * "topographymetadata" -> Basic semantic checks for TopographyDataItems
+  "xmlmetadataschema" -> validate the XML-metadata against XSD-schema
 * "overlappingscenes" -> check if subblocks at pyramid-layer 0 of different scenes are overlapping
 * "subblkbitmapvalid" -> SubBlock-Segments in SubBlockDirectory are valid and valid content
 ```

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -39,6 +39,9 @@ Options:
   -d,--printdetails BOOLEAN   Specifies whether to print details (if available) with a
                               finding. The argument may be one of 'true', 'false', 'yes'
                               or 'no'.
+  -l,--laxparsing BOOLEAN     Specifies whether lax parsing for file opening is enabled.
+                              The argument may be one of 'true', 'false', 'yes'
+                              or 'no'. Default is 'no'.
 
 
 The exit code of CZICheck is

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -6,7 +6,7 @@
 Running CZICheck with the `--help` option will print a brief summary of the available options and their usage:
 
 ```
-CZICheck version 0.1.2, using libCZI version 0.58.1
+CZICheck version 0.3.0, using libCZI version 0.59.0
 
 Usage: CZICheck [OPTIONS]
 
@@ -39,6 +39,7 @@ Options:
   -d,--printdetails BOOLEAN   Specifies whether to print details (if available) with a
                               finding. The argument may be one of 'true', 'false', 'yes'
                               or 'no'.
+
   -l,--laxparsing BOOLEAN     Specifies whether lax parsing for file opening is enabled.
                               The argument may be one of 'true', 'false', 'yes'
                               or 'no'. Default is 'no'.
@@ -62,7 +63,7 @@ Available checkers (checkers enabled with the default set are marked with '*'):
 * "consecutiveplaneindices" -> Check that planes have consecutive indices
 * "minallsubblks" -> check if all subblocks have the M index
 * "basicxmlmetadata" -> Basic semantic checks of the XML-metadata
-  "xmlmetadataschema" -> validate the XML-metadata against XSD-schema
+* "topographymetadata" -> Basic semantic checks for TopographyDataItems
 * "overlappingscenes" -> check if subblocks at pyramid-layer 0 of different scenes are overlapping
 * "subblkbitmapvalid" -> SubBlock-Segments in SubBlockDirectory are valid and valid content
 ```

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -8,3 +8,4 @@ version history                 {#version_history}
  0.1.2          | [9](https://github.com/ZEISS/czicheck/pull/9)        | add checker "subblkbitmapvalid"
  0.2.0          | [10](https://github.com/ZEISS/czicheck/pull/10)      | add checker "topographymetadata"
  0.2.1          | [11](https://github.com/ZEISS/czicheck/pull/11)      | disallow DTD-processing (prevent XXE-vulnerability)
+ 0.3.0          | [11](https://github.com/ZEISS/czicheck/pull/15)      | enable strict parsing


### PR DESCRIPTION
## Description

Added command line argument to enable strict parsing.
Use strict parsing when opening the file if command line argument says to.

Fixes #14 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
Provide instructions to reproduce.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
