### PR TITLE
Add check for ComponentBitCount to checkerXmlBasicMetadataValidation.cpp

### DIFF
--- a/CZICheck/checkers/checkerXmlBasicMetadataValidation.cpp
+++ b/CZICheck/checkers/checkerXmlBasicMetadataValidation.cpp
@@ -204,7 +204,16 @@ void CCheckBasicMetadataValidation::CheckPixelTypeInformation(const std::shared_
         {
             CResultGatherer::Finding finding(CCheckBasicMetadataValidation::kCheckType);
             finding.severity = CResultGatherer::Severity::Info;
-            finding.information = "No valid channel-information found in metadata";
+            finding.information = "No valid channel pixel_type information found in metadata";
+            this->result_gatherer_.ReportFinding(finding);
+        }
+
+        int channel_info_component_bit_count;
+        if (!channel_info->TryGetComponentBitCount(&channel_info_component_bit_count))
+        {
+            CResultGatherer::Finding finding(CCheckBasicMetadataValidation::kCheckType);
+            finding.severity = CResultGatherer::Severity::Warning;
+            finding.information = "No valid channel component_bit_count information found in metadata";
             this->result_gatherer_.ReportFinding(finding);
         }
     }


### PR DESCRIPTION
Add a check for ComponentBitCount in the Dimensions.Channels.Channel metadata.  If Channel metadata is present, the ChannelBitCount is used in ZEN applications and must be correct.

## Description

CZI files with Dimension.Channels.Channel metadata must populate the ComponentBitCount field in this metadata.  If channels are present, this value must reflect the bit count of the pixels of the subblocks in this channel.

Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
Provide instructions to reproduce.

## Checklist:

- [X] I followed the Contributing Guidelines.
- [X] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
