### PR TITLE
check if the specified channels in the appliance metadata exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(CZICheck 
-      VERSION 0.4.0
+      VERSION 0.5.0
       HOMEPAGE_URL "https://github.com/ZEISS/czicheck"
       DESCRIPTION "CZICheck is a validator for CZI-documents")
 

--- a/CZICheck/CMakeLists.txt
+++ b/CZICheck/CMakeLists.txt
@@ -166,6 +166,7 @@ if (CZICHECK_BUILD_TESTS)
           -r jpgxrcompressed_inconsistent_pixeltype.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.czi}
           -r edf-missing-texture.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/edf-missing-texture.czi}
           -r edf-superfluous.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/edf-superfluous.czi}
+          -r edf-superfluous-missing-channel-subblock.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.czi}
           -r invalid_componentbitcount.czi=DATA{${CMAKE_CURRENT_SOURCE_DIR}/../Test/CZICheckSamples/invalid_componentbitcount.czi}
     )
 

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -238,6 +238,11 @@ bool CCheckTopographyApplianceMetadata::ExtractMetaDataDimensions(const std::sha
 
 bool CCheckTopographyApplianceMetadata::CheckExistenceOfSpecifiedChannels(std::unordered_map<int, bool>& indices_set)
 {
+    if (std::all_of(indices_set.cbegin(), indices_set.cend(), [](const auto& el) { return el.second; }))
+    {
+        return true;
+    }
+
     this->reader_->EnumerateSubBlocks([this, &indices_set](int index, const SubBlockInfo& info) -> bool
     {
         int current_start_c { -1 };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -257,10 +257,7 @@ bool CCheckTopographyApplianceMetadata::CheckExistenceOfSpecifiedChannels(std::u
         return true;
     });
 
-    bool all_specified_channels_exist { true };
-    std::for_each(indices_set.cbegin(), indices_set.cend(), [&all_specified_channels_exist](auto& el){ all_specified_channels_exist &= el.second;});
-
-    return all_specified_channels_exist;
+    return std::all_of(indices_set.cbegin(), indices_set.cend(), [](const auto& el) { return el.second; });
 }
 
 bool CCheckTopographyApplianceMetadata::SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>& vec, std::vector<std::unordered_map<char, DimensionView>>& view)

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -241,10 +241,11 @@ bool CCheckTopographyApplianceMetadata::CheckExistenceOfSpecifiedChannels(std::u
     this->reader_->EnumerateSubBlocks([this, &indices_set](int index, const SubBlockInfo& info) -> bool
     {
         int current_start_c { -1 };
-        // for (const auto& channel_index : indices_set)
-        // {
         info.coordinate.TryGetPosition(libCZI::DimensionIndex::C, &current_start_c);
-        // }
+        // Here we check if any of the specified (in the topography metadata) channel indices
+        // match the StartC index of the current subblock in the subblock collection we are iterating over.
+        // When this is the case, we set the corresponding boolean to true, indicating the existence of the
+        // channel index it corresponds with (in the dictionary) in the subblock collection.
         for (auto& el : indices_set)
         {
             el.second |= current_start_c == el.first;

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -241,7 +241,10 @@ bool CCheckTopographyApplianceMetadata::CheckExistenceOfSpecifiedChannels(std::u
     this->reader_->EnumerateSubBlocks([this, &indices_set](int index, const SubBlockInfo& info) -> bool
     {
         int current_start_c { -1 };
-        info.coordinate.TryGetPosition(libCZI::DimensionIndex::C, &current_start_c);
+        if (!info.coordinate.TryGetPosition(libCZI::DimensionIndex::C, &current_start_c))
+        {
+            return true;
+        }
         // Here we check if any of the specified (in the topography metadata) channel indices
         // match the StartC index of the current subblock in the subblock collection we are iterating over.
         // When this is the case, we set the corresponding boolean to true, indicating the existence of the

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -93,7 +93,7 @@ void CCheckTopographyApplianceMetadata::CheckValidDimensionInTopographyDataItems
         }
 
         // arriving here, the channel indices left are valid and can be added to a set of channel indices
-        for (const auto& el: txt)
+        for (const auto& el : txt)
         {
             if (el.second.DimensionIndex == libCZI::DimensionIndex::C)
             {
@@ -112,7 +112,7 @@ void CCheckTopographyApplianceMetadata::CheckValidDimensionInTopographyDataItems
         }
 
         // arriving here, the channel indices left are valid and can be added to a set of channel indices
-        for (const auto& el: hmp)
+        for (const auto& el : hmp)
         {
             if (el.second.DimensionIndex == libCZI::DimensionIndex::C)
             {

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.cpp
@@ -151,10 +151,10 @@ bool CCheckTopographyApplianceMetadata::ExtractMetaDataDimensions(const std::sha
     // within the TopographyData we allow
     // any number of TopographyDataItem which itself can contain a set of Texutures and a set of heightmaps
     // within the heightmaps AND Textures, each item reside in its own channel.
-    string topography_path{ this->kImageAppliancePath };
+    string topography_path{ CCheckTopographyApplianceMetadata::kImageAppliancePath };
     topography_path
         .append("/Appliance[Id=")
-        .append(this->kTopographyItemId)
+        .append(CCheckTopographyApplianceMetadata::kTopographyItemId)
         .append("]");
 
     const auto topo_metadata{ czi_metadata->GetChildNodeReadonly(topography_path.c_str()) };

--- a/CZICheck/checkers/checkerTopographyApplianceValidation.h
+++ b/CZICheck/checkers/checkerTopographyApplianceValidation.h
@@ -57,5 +57,6 @@ private:
     void CheckValidDimensionInTopographyDataItems(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 
     bool SetBoundsFromVector(const std::vector<std::pair<std::wstring, std::wstring>>&, std::vector<std::unordered_map<char, DimensionView>>&);
+    bool CheckExistenceOfSpecifiedChannels(std::unordered_map<int, bool>& indices_set);
     bool ExtractMetaDataDimensions(const std::shared_ptr<libCZI::ICziMetadata>& czi_metadata);
 };

--- a/Test/CZICheckSamples/TestCasesLists.txt
+++ b/Test/CZICheckSamples/TestCasesLists.txt
@@ -31,3 +31,4 @@ jpgxrcompressed_inconsistent_pixeltype.czi,2,jpgxrcompressed_inconsistent_pixelt
 edf-missing-texture.czi,2,edf-missing-texture.txt
 edf-superfluous.czi,2,edf-superfluous.txt
 invalid_componentbitcount.czi,1,invalid_componentbitcount.txt
+edf-superfluous-missing-channel-subblock.czi,2,edf-superfluous-missing-channel-subblock.txt

--- a/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.czi.md5
+++ b/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.czi.md5
@@ -1,0 +1,1 @@
+431bced0beeeee3b6616bc0c5fe19d1e

--- a/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt
+++ b/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt
@@ -1,0 +1,29 @@
+Test "SubBlock-Segment in SubBlockDirectory within file" : OK
+Test "SubBlock-Segments in SubBlockDirectory are valid" : OK
+Test "check subblock's coordinates for 'consistent dimensions'" : OK
+Test "check subblock's coordinates being unique" : OK
+Test "check whether the document uses the deprecated 'B-index'" : OK
+Test "check that the subblocks of a channel have the same pixeltype" : OK
+Test "Check that planes indices start at 0" : OK
+Test "Check that planes have consecutive indices" : OK
+Test "check if all subblocks have the M index" : OK
+Test "Basic semantic checks of the XML-metadata" :
+  document statistics gives 1 channels, whereas in XML-metadata 2 channels are found.
+  No sub block-information found for channel index 1, metadata pixelType: gray32float
+  No valid ComponentBitCount information found in metadata for channel #1.
+ WARN
+Test "validate the XML-metadata against XSD-schema" :
+  (120,22): no declaration found for element 'RotationCenter'
+  (126,15): element 'RotationCenter' is not allowed for content model 'All(SessionMatrix?,HolderZeissName?,HolderZeissId?,HolderCwsId?,SessionCount?,SessionRotationAtStart?,CustomAttributes?)'
+  (222,29): attribute 'Id' is not declared for element 'Scaling'
+  <1 more finding omitted> 
+ FAIL
+Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
+Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
+Test "Basic semantic checks for TopographyDataItems" :
+  There are superfluous dimensions specified in the TopographyDataItems. This might yield errors.
+  The Topography metadata specifies channels for the texture or heightmap subblocks, that are not present in the Subblock Collection of the image.
+ FAIL
+
+
+Result: Errors Detected

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -10,3 +10,4 @@ version history                 {#version_history}
  0.2.1          | [11](https://github.com/ZEISS/czicheck/pull/11)      | disallow DTD-processing (prevent XXE-vulnerability)
  0.3.0          | [11](https://github.com/ZEISS/czicheck/pull/15)      | enable strict parsing
  0.4.0          | [19](https://github.com/ZEISS/czicheck/pull/19)      | add check for "ComponentBitCount" to basicxmlmetadata-checker
+ 0.5.0          | [20](https://github.com/ZEISS/czicheck/pull/20)      | enhance "topographymetadata" checker


### PR DESCRIPTION
## Description

The current topography metadata checker only checks if the specified metadata is "valid".
It however might as well be the case that a channel that was specified in the metadata section is not at all present in the subblock collection, rendering the topography spec invalid.
This PR adds functionality to check the subblock collection for the channels that the `TopographyDataItem` wishes to see in the image document.

Fixes #8

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I created a new "broken" image for test purposes to verify the intended behaviour. I'd like to add/replace this new file to the testdata collection and include the new "expected results" in the repo to have this test included to the CI pipeline.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
