### PR TITLE
Add option to ignore 'SizeM' for pyramid subblocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(CZICheck 
-      VERSION 0.6.2
+      VERSION 0.6.3
       HOMEPAGE_URL "https://github.com/ZEISS/czicheck"
       DESCRIPTION "CZICheck is a validator for CZI-documents")
 

--- a/CZICheck/cmdlineoptions.h
+++ b/CZICheck/cmdlineoptions.h
@@ -27,6 +27,7 @@ private:
     int max_number_of_findings_to_print_;
     bool print_details_of_messages_;
     bool lax_parsing_enabled_;
+    bool ignore_sizem_for_pyramid_subblocks_;
     OutputEncodingFormat result_encoding_type_ { OutputEncodingFormat::TEXT };
 public:
     /// Values that represent the result of the "Parse"-operation.
@@ -51,6 +52,7 @@ public:
     [[nodiscard]] int GetMaxNumberOfMessagesToPrint() const { return this->max_number_of_findings_to_print_; }
     [[nodiscard]] bool GetPrintDetailsOfMessages() const { return this->print_details_of_messages_; }
     [[nodiscard]] bool GetLaxParsingEnabled() const { return this->lax_parsing_enabled_; }
+    [[nodiscard]] bool GetIgnoreSizeMForPyramidSubBlocks() const { return this->ignore_sizem_for_pyramid_subblocks_; }
     [[nodiscard]] const std::vector<CZIChecks>& GetChecksEnabled() const { return this->checks_enabled_; }
     [[nodiscard]] const std::shared_ptr<ILog>& GetLog() const { return this->log_; }
     [[nodiscard]] const OutputEncodingFormat GetOutputEncodingFormat() const { return this->result_encoding_type_; }

--- a/CZICheck/runchecks.cpp
+++ b/CZICheck/runchecks.cpp
@@ -40,6 +40,7 @@ bool CRunChecks::Run(IResultGatherer::AggregatedResult& result)
     {
         ICZIReader::OpenOptions options;
         options.lax_subblock_coordinate_checks = this->opts.GetLaxParsingEnabled();
+        options.ignore_sizem_for_pyramid_subblocks = this->opts.GetIgnoreSizeMForPyramidSubBlocks();
         spReader->Open(stream, &options);
     }
     catch (exception& ex)

--- a/Test/CZICheckSamples/differentpixeltypeinchannel.txt.json
+++ b/Test/CZICheckSamples/differentpixeltypeinchannel.txt.json
@@ -112,6 +112,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/differentpixeltypeinchannel.txt.xml
+++ b/Test/CZICheckSamples/differentpixeltypeinchannel.txt.xml
@@ -99,6 +99,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/duplicate_coordinates.txt.json
+++ b/Test/CZICheckSamples/duplicate_coordinates.txt.json
@@ -112,6 +112,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/duplicate_coordinates.txt.xml
+++ b/Test/CZICheckSamples/duplicate_coordinates.txt.xml
@@ -99,6 +99,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/edf-missing-texture.txt.json
+++ b/Test/CZICheckSamples/edf-missing-texture.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/edf-missing-texture.txt.xml
+++ b/Test/CZICheckSamples/edf-missing-texture.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.json
+++ b/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.json
@@ -126,6 +126,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.xml
+++ b/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.xml
@@ -113,6 +113,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/edf-superfluous.txt.json
+++ b/Test/CZICheckSamples/edf-superfluous.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/edf-superfluous.txt.xml
+++ b/Test/CZICheckSamples/edf-superfluous.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/inconsistent_coordinates.txt.json
+++ b/Test/CZICheckSamples/inconsistent_coordinates.txt.json
@@ -112,6 +112,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/inconsistent_coordinates.txt.xml
+++ b/Test/CZICheckSamples/inconsistent_coordinates.txt.xml
@@ -99,6 +99,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/invalid_componentbitcount.txt.json
+++ b/Test/CZICheckSamples/invalid_componentbitcount.txt.json
@@ -94,6 +94,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/invalid_componentbitcount.txt.xml
+++ b/Test/CZICheckSamples/invalid_componentbitcount.txt.xml
@@ -81,6 +81,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.json
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.json
@@ -100,6 +100,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.xml
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.xml
@@ -87,6 +87,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.json
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.json
@@ -100,6 +100,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.xml
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.xml
@@ -87,6 +87,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.json
+++ b/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.json
@@ -100,6 +100,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.xml
+++ b/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.xml
@@ -87,6 +87,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/negative_plane_start_index.txt.json
+++ b/Test/CZICheckSamples/negative_plane_start_index.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/negative_plane_start_index.txt.xml
+++ b/Test/CZICheckSamples/negative_plane_start_index.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/overlapping_scenes.txt.json
+++ b/Test/CZICheckSamples/overlapping_scenes.txt.json
@@ -136,6 +136,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/overlapping_scenes.txt.xml
+++ b/Test/CZICheckSamples/overlapping_scenes.txt.xml
@@ -123,6 +123,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.json
+++ b/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.json
@@ -181,6 +181,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.xml
+++ b/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.xml
@@ -168,6 +168,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/positive_plane_start_index.txt.json
+++ b/Test/CZICheckSamples/positive_plane_start_index.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/positive_plane_start_index.txt.xml
+++ b/Test/CZICheckSamples/positive_plane_start_index.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/sparse_planes.txt.json
+++ b/Test/CZICheckSamples/sparse_planes.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.6.2"
+        "version": "0.6.3"
     }
 }

--- a/Test/CZICheckSamples/sparse_planes.txt.xml
+++ b/Test/CZICheckSamples/sparse_planes.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </OutputVersion>
 </TestResults>

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -15,3 +15,4 @@ version history                 {#version_history}
  0.6.0          | [22](https://github.com/ZEISS/czicheck/pull/22)      | enable machine readable output in json and xml format
  0.6.1          | [28](https://github.com/ZEISS/czicheck/pull/28)      | update of metadata-schema (including Lf4d)
  0.6.2          | [29](https://github.com/ZEISS/czicheck/pull/29)      | fix issue in metadata-schema (with "TopographyDataItem" and with AxioScan-documents)
+ 0.6.3          | [31](https://github.com/ZEISS/czicheck/pull/31)      | add option to ignore "size-m-field-for-pyramid-subblocks"


### PR DESCRIPTION
## Description

This commit introduces a new command line option `-i, --ignoresizem` in the `CCmdLineOptions` class, allowing users to specify whether to ignore the 'SizeM' field for pyramid subblocks.
This allows CZICheck to operate on some malformed CZIs, which otherwise would not be analyzable at all - because libCZI refuses to open them.  By instructing libCZI to ignore this bogus piece of information, CZICheck-analysis can be done.
Note that, regrettably, when using this flag, CZICheck does not give an indication anymore that there is something wrong (regarding this error which is now ignored). This is motivation to *not* turn it on by default.

Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
