### PR TITLE
pin libCZI version to "before vckpkg"

### DIFF
--- a/Test/CZICheckSamples/TestCasesLists.txt
+++ b/Test/CZICheckSamples/TestCasesLists.txt
@@ -26,8 +26,8 @@ pixeltype_mismatch_between_metadata_and_subblocks.czi,2,pixeltype_mismatch_betwe
 # Note that this does not compare the output to stdout - '*' is a special value instruction to skip this test.
 inaccessible_file.czi,5,*
 overlapping_scenes.czi,2,overlapping_scenes.txt
-jpgxrcompressed_inconsistent_size.czi,2,jpgxrcompressed_inconsistent_size.txt
-jpgxrcompressed_inconsistent_pixeltype.czi,2,jpgxrcompressed_inconsistent_pixeltype.txt
+jpgxrcompressed_inconsistent_size.czi,1,jpgxrcompressed_inconsistent_size.txt
+jpgxrcompressed_inconsistent_pixeltype.czi,1,jpgxrcompressed_inconsistent_pixeltype.txt
 edf-missing-texture.czi,2,edf-missing-texture.txt
 edf-superfluous.czi,2,edf-superfluous.txt
 invalid_componentbitcount.czi,1,invalid_componentbitcount.txt

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt
@@ -12,10 +12,8 @@ Test "Basic semantic checks of the XML-metadata" :
  WARN
 Test "validate the XML-metadata against XSD-schema" : OK
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
-Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" :
-  Error decoding subblock #0 with compression "jpgxr"
- FAIL
+Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
 Test "Basic semantic checks for TopographyDataItems" : OK
 
 
-Result: Errors Detected
+Result: With Warnings

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.json
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.json
@@ -1,5 +1,5 @@
 {
-    "aggregatedresult": "FAIL",
+    "aggregatedresult": "WARN",
     "tests": [
         {
             "name": "SubBlockDirectoryPositionsWithinRange",
@@ -82,14 +82,8 @@
         {
             "name": "CheckSubBlockBitmapValid",
             "description": "SubBlock-Segments in SubBlockDirectory are valid and valid content",
-            "result": "FAIL",
-            "findings": [
-                {
-                    "severity": "FATAL",
-                    "description": "Error decoding subblock #0 with compression \"jpgxr\"",
-                    "details": "pixel type mismatch: expected \"gray8\", but got \"gray16\""
-                }
-            ]
+            "result": "OK",
+            "findings": []
         },
         {
             "name": "ApplianceMetadataTopographyItemValid",

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.xml
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.xml
@@ -69,14 +69,8 @@
     </Test>
     <Test Name="CheckSubBlockBitmapValid">
       <Description>SubBlock-Segments in SubBlockDirectory are valid and valid content</Description>
-      <Result>FAIL</Result>
-      <Findings>
-        <Finding>
-          <Severity>FATAL</Severity>
-          <Description>Error decoding subblock #0 with compression "jpgxr"</Description>
-          <Details>pixel type mismatch: expected "gray8", but got "gray16"</Details>
-        </Finding>
-      </Findings>
+      <Result>OK</Result>
+      <Findings />
     </Test>
     <Test Name="ApplianceMetadataTopographyItemValid">
       <Description>Basic semantic checks for TopographyDataItems</Description>
@@ -84,7 +78,7 @@
       <Findings />
     </Test>
   </Tests>
-  <AggregatedResult>FAIL</AggregatedResult>
+  <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
     <Version>0.6.3</Version>

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt
@@ -12,10 +12,8 @@ Test "Basic semantic checks of the XML-metadata" :
  WARN
 Test "validate the XML-metadata against XSD-schema" : OK
 Test "check if subblocks at pyramid-layer 0 of different scenes are overlapping" : OK
-Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" :
-  Error decoding subblock #0 with compression "jpgxr"
- FAIL
+Test "SubBlock-Segments in SubBlockDirectory are valid and valid content" : OK
 Test "Basic semantic checks for TopographyDataItems" : OK
 
 
-Result: Errors Detected
+Result: With Warnings

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.json
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.json
@@ -1,5 +1,5 @@
 {
-    "aggregatedresult": "FAIL",
+    "aggregatedresult": "WARN",
     "tests": [
         {
             "name": "SubBlockDirectoryPositionsWithinRange",
@@ -82,14 +82,8 @@
         {
             "name": "CheckSubBlockBitmapValid",
             "description": "SubBlock-Segments in SubBlockDirectory are valid and valid content",
-            "result": "FAIL",
-            "findings": [
-                {
-                    "severity": "FATAL",
-                    "description": "Error decoding subblock #0 with compression \"jpgxr\"",
-                    "details": "size mismatch: expected 4x4, but got 3x3"
-                }
-            ]
+            "result": "OK",
+            "findings": []
         },
         {
             "name": "ApplianceMetadataTopographyItemValid",

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.xml
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.xml
@@ -69,14 +69,8 @@
     </Test>
     <Test Name="CheckSubBlockBitmapValid">
       <Description>SubBlock-Segments in SubBlockDirectory are valid and valid content</Description>
-      <Result>FAIL</Result>
-      <Findings>
-        <Finding>
-          <Severity>FATAL</Severity>
-          <Description>Error decoding subblock #0 with compression "jpgxr"</Description>
-          <Details>size mismatch: expected 4x4, but got 3x3</Details>
-        </Finding>
-      </Findings>
+      <Result>OK</Result>
+      <Findings />
     </Test>
     <Test Name="ApplianceMetadataTopographyItemValid">
       <Description>Basic semantic checks for TopographyDataItems</Description>
@@ -84,7 +78,7 @@
       <Findings />
     </Test>
   </Tests>
-  <AggregatedResult>FAIL</AggregatedResult>
+  <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
     <Version>0.6.3</Version>

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -16,3 +16,4 @@ version history                 {#version_history}
  0.6.1          | [28](https://github.com/ZEISS/czicheck/pull/28)      | update of metadata-schema (including Lf4d)
  0.6.2          | [29](https://github.com/ZEISS/czicheck/pull/29)      | fix issue in metadata-schema (with "TopographyDataItem" and with AxioScan-documents)
  0.6.3          | [31](https://github.com/ZEISS/czicheck/pull/31)      | add option to ignore "size-m-field-for-pyramid-subblocks"
+ 0.6.4          | [34](https://github.com/ZEISS/czicheck/pull/34)      | align with libCZI version 0.64.0

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -16,4 +16,4 @@ version history                 {#version_history}
  0.6.1          | [28](https://github.com/ZEISS/czicheck/pull/28)      | update of metadata-schema (including Lf4d)
  0.6.2          | [29](https://github.com/ZEISS/czicheck/pull/29)      | fix issue in metadata-schema (with "TopographyDataItem" and with AxioScan-documents)
  0.6.3          | [31](https://github.com/ZEISS/czicheck/pull/31)      | add option to ignore "size-m-field-for-pyramid-subblocks"
- 0.6.4          | [34](https://github.com/ZEISS/czicheck/pull/34)      | align with libCZI version 0.64.0
+ 0.6.4          | [34](https://github.com/ZEISS/czicheck/pull/34)      | align with libCZI 0.64.0 and pin version

--- a/modules/libCZI.cmake
+++ b/modules/libCZI.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
   libCZI
   GIT_REPOSITORY https://github.com/ZEISS/libczi.git
-  GIT_TAG        origin/main
+  GIT_TAG        545098455ef50fdc7d4d8615bfa0c5bd78f52df7
 )
 
 if(NOT libCZI_POPULATED)


### PR DESCRIPTION
## Description

This is a makeshift fix. It pins the libCZI dependency of this project to before the vcpkg additions in libCZI.
 Once CZICheck needs new features of libCZI, it must be "fixed appropriately".

Note: this now makes use of libCZI `0.64.0`. This also has implications on what "is legal" in the scope of a czi and thus requires adaptions to the expected results.
C.f., [libCZI PR 130](https://github.com/ZEISS/libczi/pull/130)

This is reflected in a version bump as well.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local build works + CI build triggered.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
