### PR TITLE
Update CZICheck to 0.7.4 and schema for new mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(CZICHECK_ENABLE_VCPKG_BOOTSTRAP)
 endif()
 
 project(CZICheck 
-      VERSION 0.7.3
+      VERSION 0.7.4
       HOMEPAGE_URL "https://github.com/ZEISS/czicheck"
       DESCRIPTION "CZICheck is a validator for CZI-documents")
 

--- a/CZICheck/checkers/schema/ZEN/flatten/ImageMetadata.xsd
+++ b/CZICheck/checkers/schema/ZEN/flatten/ImageMetadata.xsd
@@ -4338,35 +4338,35 @@
             <xs:element form="qualified" maxOccurs="1" minOccurs="0" name="AcquisitionMode">
                 <xs:annotation>
                     <xs:documentation>
-                        AcquisitionMode describes the type of microscopy
-                        performed for each channel.             Possible modes:
-                        WideField             LaserScanningConfocalMicroscopy     - CLSM or LSCM
-                        SpinningDiskConfocal             SlitScanConfocal
-                        StructuredIllumination             SingleMoleculeImaging
-                        TotalInternalReflection             FluorescenceLifetime
-                        SpectralImaging             FluorescenceCorrelationSpectroscopy
-                        NearFieldScanningOpticalMicroscopy  - NSOM
-                        SecondHarmonicGenerationImaging     - Second harmonic imaging microscopy
-                        (SHIM)             PALM                                - photo-activated
-                        localization microscopy, photo-activation localization microscopy
-                        STORM                               - stochastic optical reconstruction
-                        microscopy             STED                                - stimulated
-                        emission depletion             TIRF                                - total
-                        internal reflection fluorescence (TIRFM)             FSM
-                        - Fluorescence speckle microscopy             LCM
-                        - Laser capture microdissection             SPIM
-                        - Selective Plane Illumination             SEM
-                        - Scanning Electron Microscopy             FIB
-                        - Focus Ion Beam             FIB-SEM                             - Focus Ion
-                        Beam - Scanning Electron Microscopy             AngularIllumination
-                        - Angular illumination, uses bright field illumination via LED Matrix
-                        LatticeLightsheet                   - Lattice lightsheet
-                        LatticeLightsheetSmlm               - Single molecule localization
-                        microscopy (SMLM) with Lattice Lightsheet
-                        StructuredIlluminationSr            - Structured Illumination with super
-                        resolution (Elyra, Lattice SIM)             LightField
-                        - Light field microscope (LFM) based on micro lens array             Other
-                    </xs:documentation>
+						AcquisitionMode describes the type of microscopy
+						performed for each channel.             Possible modes:
+						WideField             LaserScanningConfocalMicroscopy     - CLSM or LSCM
+						SpinningDiskConfocal             SlitScanConfocal
+						StructuredIllumination             SingleMoleculeImaging    SingleMoleculeLocalisation
+						TotalInternalReflection             FluorescenceLifetime
+						SpectralImaging             FluorescenceCorrelationSpectroscopy
+						NearFieldScanningOpticalMicroscopy  - NSOM
+						SecondHarmonicGenerationImaging     - Second harmonic imaging microscopy
+						(SHIM)             PALM                                - photo-activated
+						localization microscopy, photo-activation localization microscopy
+						STORM                               - stochastic optical reconstruction
+						microscopy             STED                                - stimulated
+						emission depletion             TIRF                                - total
+						internal reflection fluorescence (TIRFM)             FSM
+						- Fluorescence speckle microscopy             LCM
+						- Laser capture microdissection             SPIM
+						- Selective Plane Illumination             SEM
+						- Scanning Electron Microscopy             FIB
+						- Focus Ion Beam             FIB-SEM                             - Focus Ion
+						Beam - Scanning Electron Microscopy             AngularIllumination
+						- Angular illumination, uses bright field illumination via LED Matrix
+						LatticeLightsheet                   - Lattice lightsheet
+						LatticeLightsheetSmlm               - Single molecule localization
+						microscopy (SMLM) with Lattice Lightsheet
+						StructuredIlluminationSr            - Structured Illumination with super
+						resolution (Elyra, Lattice SIM)             LightField
+						- Light field microscope (LFM) based on micro lens array             Other
+					</xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
@@ -4379,6 +4379,7 @@
 
                         <xs:enumeration value="StructuredIllumination"/>
                         <xs:enumeration value="SingleMoleculeImaging"/>
+                        <xs:enumeration value="SingleMoleculeLocalisation"/>
                         <xs:enumeration value="TotalInternalReflection"/>
                         <xs:enumeration value="FluorescenceLifetime"/>
                         <xs:enumeration value="SpectralImaging"/>

--- a/Test/CZICheckSamples/differentpixeltypeinchannel.txt.json
+++ b/Test/CZICheckSamples/differentpixeltypeinchannel.txt.json
@@ -112,6 +112,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/differentpixeltypeinchannel.txt.xml
+++ b/Test/CZICheckSamples/differentpixeltypeinchannel.txt.xml
@@ -99,6 +99,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/duplicate_coordinates.txt.json
+++ b/Test/CZICheckSamples/duplicate_coordinates.txt.json
@@ -112,6 +112,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/duplicate_coordinates.txt.xml
+++ b/Test/CZICheckSamples/duplicate_coordinates.txt.xml
@@ -99,6 +99,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/edf-missing-texture.txt.json
+++ b/Test/CZICheckSamples/edf-missing-texture.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/edf-missing-texture.txt.xml
+++ b/Test/CZICheckSamples/edf-missing-texture.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.json
+++ b/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.json
@@ -126,6 +126,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.xml
+++ b/Test/CZICheckSamples/edf-superfluous-missing-channel-subblock.txt.xml
@@ -113,6 +113,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/edf-superfluous.txt.json
+++ b/Test/CZICheckSamples/edf-superfluous.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/edf-superfluous.txt.xml
+++ b/Test/CZICheckSamples/edf-superfluous.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/inconsistent_coordinates.txt.json
+++ b/Test/CZICheckSamples/inconsistent_coordinates.txt.json
@@ -112,6 +112,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/inconsistent_coordinates.txt.xml
+++ b/Test/CZICheckSamples/inconsistent_coordinates.txt.xml
@@ -99,6 +99,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/invalid_componentbitcount.txt.json
+++ b/Test/CZICheckSamples/invalid_componentbitcount.txt.json
@@ -94,6 +94,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/invalid_componentbitcount.txt.xml
+++ b/Test/CZICheckSamples/invalid_componentbitcount.txt.xml
@@ -81,6 +81,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.json
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.json
@@ -94,6 +94,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.xml
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_pixeltype.txt.xml
@@ -81,6 +81,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.json
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.json
@@ -94,6 +94,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.xml
+++ b/Test/CZICheckSamples/jpgxrcompressed_inconsistent_size.txt.xml
@@ -81,6 +81,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.json
+++ b/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.json
@@ -100,6 +100,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.xml
+++ b/Test/CZICheckSamples/layer_0_subblocks_with_no_m_index.txt.xml
@@ -87,6 +87,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/negative_plane_start_index.txt.json
+++ b/Test/CZICheckSamples/negative_plane_start_index.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/negative_plane_start_index.txt.xml
+++ b/Test/CZICheckSamples/negative_plane_start_index.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/overlapping_scenes.txt.json
+++ b/Test/CZICheckSamples/overlapping_scenes.txt.json
@@ -115,6 +115,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/overlapping_scenes.txt.xml
+++ b/Test/CZICheckSamples/overlapping_scenes.txt.xml
@@ -102,6 +102,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.json
+++ b/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.json
@@ -181,6 +181,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.xml
+++ b/Test/CZICheckSamples/pixeltype_mismatch_between_metadata_and_subblocks.txt.xml
@@ -168,6 +168,6 @@
   <AggregatedResult>FAIL</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/positive_plane_start_index.txt.json
+++ b/Test/CZICheckSamples/positive_plane_start_index.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/positive_plane_start_index.txt.xml
+++ b/Test/CZICheckSamples/positive_plane_start_index.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/Test/CZICheckSamples/sparse_planes.txt.json
+++ b/Test/CZICheckSamples/sparse_planes.txt.json
@@ -105,6 +105,6 @@
     ],
     "output_version": {
         "command": "CZICheck",
-        "version": "0.7.3"
+        "version": "0.7.4"
     }
 }

--- a/Test/CZICheckSamples/sparse_planes.txt.xml
+++ b/Test/CZICheckSamples/sparse_planes.txt.xml
@@ -92,6 +92,6 @@
   <AggregatedResult>WARN</AggregatedResult>
   <OutputVersion>
     <Command>CZICheck</Command>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
   </OutputVersion>
 </TestResults>

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -22,3 +22,4 @@ version history                 {#version_history}
  0.7.1          | [45](https://github.com/ZEISS/czicheck/pull/45)      | update schema
  0.7.2          | [46](https://github.com/ZEISS/czicheck/pull/46)      | update the schema
  0.7.3          | [47](https://github.com/ZEISS/czicheck/pull/47)      | update the schema
+ 0.7.4          | [48](https://github.com/ZEISS/czicheck/pull/48)      | update the schema


### PR DESCRIPTION
## Description

- ImageMetadata.xsd schema updated: added "SingleMoleculeLocalisation" to AcquisitionMode and revised documentation.
- Version history updated for the new release.
- CZICheck and test outputs bumped to version 0.7.4.

Fixes # (issue)

Added missing enumeration to AcquisitionMode.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with sample CZI-Files.

## Checklist:

- [X] I followed the Contributing Guidelines.
- [X] I did a self-review.
- [X] I commented my code, particularly in hard-to-understand areas.
- [X] I updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
